### PR TITLE
Feature: Purge Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ You can install the package via composer:
 ```bash
 composer require mvdnbrk/laravel-model-expires
 ```
+
+Once installed the configuration file can be published by typing:
+
+```bash
+php artisan vendor:publish --provider="Mvdnbrk\EloquentExpirable\ExpirableServiceProvider"
+```
+
 ## Usage
 
 To use an expiration date on a model, use the `Expirable` trait:

--- a/README.md
+++ b/README.md
@@ -146,8 +146,29 @@ The `notExpiring` method will retrieve **only** models that will not expire:
 $subscriptions = App\Models\Subscription::notExpiring()->get();
 ```
 
+### Purging Records
+A CLI command to purge expired records has been provided for convenience.
+
+To make use of this feature edit the configuration file in configs/expirable.php and set the `purge` array to the class of the desired model.  When doing so be sure to include the 'Expirable' trait as per the example above otherwise the command will output an error.
+
+```php
+    'purge' => [
+        \App\Models\Subscription::class,
+    ],
+```
+
+To run the command simply execute `php artisan expirable:purge`  and you should see output similar to the following:
+
+```bash
+Deleting expired records...
+
+App\Models\Subscription: 
+11 records deleted.
+
+Purge completed!
+```
+
 ### Todo
-- Add a `expired:prune` console command to delete expired models, or perform custom implementation.
 - Add a query scope that will query models that will expire in `...`
 
 ## Testing

--- a/config/expirable.php
+++ b/config/expirable.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Purge
+    |--------------------------------------------------------------------------
+    |
+    | Models that should be purged by the expirable:purge command.
+    |
+    | (see the README file for an example)
+    |
+    */
+
+    'purge' => [],
+
+];

--- a/src/ExpirableServiceProvider.php
+++ b/src/ExpirableServiceProvider.php
@@ -10,6 +10,25 @@ class ExpirableServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->registerBlueprintMacros();
+
+        // Merge default config
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/expirable.php',
+            'expirable'
+        );
+
+        // Register commands
+        $this->commands([
+            PurgeExpired::class,
+        ]);
+    }
+
+    public function boot(): void
+    {
+        // Publish config
+        $this->publishes([
+            __DIR__ . '/../config/expirable.php' => config_path('expirable.php'),
+        ]);
     }
 
     protected function registerBlueprintMacros(): void

--- a/src/PurgeExpired.php
+++ b/src/PurgeExpired.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Mvdnbrk\EloquentExpirable;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class PurgeExpired extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'expirable:purge';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete the expired records.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->comment('Deleting expired records...');
+        $this->line('');
+
+        foreach (config('expirable.purge', []) as $purgeable) {
+
+            if (in_array('Mvdnbrk\EloquentExpirable\Expirable', class_uses($purgeable))) {
+
+                $total = call_user_func($purgeable . '::onlyExpired')->forceDelete();
+
+                $this->line($purgeable . ': ');
+
+                if ($total > 0) {
+                    $this->info($total . ' ' . Str::plural('record', $total) . ' deleted.');
+                } else {
+                    $this->comment('Nothing to delete.');
+                }
+            } else {
+
+                $this->error($purgeable . ': this model is not expirable! (Expirable trait not found)');
+            }
+
+            $this->line('');
+        }
+
+        $this->info('Purge completed!');
+    }
+}


### PR DESCRIPTION
Here's that missing TODO item that implements a CLI 'purge' command for expired records.  Most of the work was already done by the folks over at 'laravel-expirable' which made adaptation quite straightforward.

Please be so kind as to review and if all up to scratch would love to see it in the codebase :)

-- Stephen